### PR TITLE
[accountbook] Fix function name in skeleton/step06

### DIFF
--- a/accountbook/skeleton/step06/accountbook.go
+++ b/accountbook/skeleton/step06/accountbook.go
@@ -34,7 +34,7 @@ func (ab *AccountBook) AddItem(item *Item) error {
 	}
 
 	// 「品目 値段」の形式でファイルに出力する
-	if _, err := /* TODO: fmt.Printlnを使って出力 */; err != nil {
+	if _, err := /* TODO: fmt.Fprintlnを使って出力 */; err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Thank you for publishing the good tutorial!

I think this function name is `fmt.Fprintln` instead of `fmt.Println`, so I fix it.
https://github.com/tenntenn/gohandson/blob/cef9691e4905e38a3ee9935c6874daa0a6a0e7bf/accountbook/skeleton/step06/accountbook.go#L37